### PR TITLE
Update app install id to new website repo

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Process config
         env:
           EC_AUTOMATION_KEY: ${{ secrets.EC_AUTOMATION_KEY }}
-          APP_INSTALL_ID: 29980719
+          APP_INSTALL_ID: 59973090
         run: |-
           set -euo pipefail
           function createJWT() {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # review-rot
 
-Repo for generating review-rot page for the EC team at
-<https://enterprise-contract.github.io/review-rot>
+Repo for generating review-rot page for the Conforma team at
+<https://conforma.dev/review-rot>

--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@ git_services:
       - enterprise-contract/ec-cli
       - enterprise-contract/ec-policies
       - enterprise-contract/enterprise-contract-controller
-      - enterprise-contract/enterprise-contract.github.io
       - enterprise-contract/.github
       - enterprise-contract/github-workflows
       - enterprise-contract/go-gather


### PR DESCRIPTION
I've just moved the website repo from
enterprise-contract/enterprise-contract.github.io to conforma/conforma.github.io.

Also updated project name and web url in readme

Ref: https://issues.redhat.com/browse/EC-1081