### PR TITLE
chore: update references to github-workflows repo

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -22,7 +22,7 @@ name: 'Auto merge'
 
 jobs:
   auto-merge:
-    uses: enterprise-contract/github-workflows/.github/workflows/auto-merge.yaml@main
+    uses: conforma/github-workflows/.github/workflows/auto-merge.yaml@main
     secrets: inherit
     permissions:
       pull-requests: write

--- a/config.yaml
+++ b/config.yaml
@@ -23,7 +23,7 @@ git_services:
       - conforma/config
       - enterprise-contract/enterprise-contract-controller
       - enterprise-contract/.github
-      - enterprise-contract/github-workflows
+      - conforma/github-workflows
       - enterprise-contract/go-containerregistry
       - enterprise-contract/infra-deployments-ci
       - enterprise-contract/policy_builder


### PR DESCRIPTION
This commit updates the references to github-workflows from `enterprise-contract/github-workflows` to `conforma/github-workflows`.

Ref: EC-1118