### PR TITLE
fix name of `pr-agent-settings` repository

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,7 +26,7 @@ git_services:
       - conforma/knative-service
       - conforma/policy
       - conforma/policy-builder
-      - conforma/pr-agents-settings
+      - conforma/pr-agent-settings
       - conforma/pr-size-label-action
       - conforma/review-rot
       - conforma/tekton-catalog


### PR DESCRIPTION
This commit addresses a typo in the name for the `pr-agent-settings` repository and changes it from `pr-agents-settings` to `pr-agent-settings`