### PR TITLE
fix: add environment block to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,6 +16,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary
- The `actions/deploy-pages@v4` action now requires the job to declare a deployment `environment` with `name: github-pages`
- GitHub started enforcing this requirement today (~10:00 UTC on 2026-05-13), causing every Publish workflow run to fail at the "Deploy pages" step with: `Missing environment`
- Adds the required `environment` block to the `publish` job

## Test plan
- [ ] Verify the next scheduled Publish workflow run (every 30 min on weekdays) completes successfully
- [ ] Confirm the GitHub Pages site deploys and the deployment URL appears in the Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)