### PR TITLE
Create output directory before writing data.json

### DIFF
--- a/cmd/review-rot/main.go
+++ b/cmd/review-rot/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/conforma/review-rot/internal/config"
@@ -71,6 +72,10 @@ func main() {
 	data, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		log.Fatalf("Failed to marshal JSON: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outputPath), 0755); err != nil {
+		log.Fatalf("Failed to create output directory: %v", err)
 	}
 
 	if err := os.WriteFile(*outputPath, data, 0644); err != nil {


### PR DESCRIPTION
## Summary
- The publish workflow passes `--output=web/data.json` but the `web/` directory doesn't exist in the repo
- `os.WriteFile` fails because the parent directory is missing
- Add `os.MkdirAll` to create the output directory before writing

Fixes the CI failure introduced in #229: https://github.com/conforma/review-rot/actions/runs/26085078868/job/76696009865

## Test plan
- [x] `go build` succeeds
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)