### PR TITLE
Create output directory before writing data.json

### DIFF
--- a/cmd/review-rot/main.go
+++ b/cmd/review-rot/main.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/conforma/review-rot/internal/config"
@@ -71,6 +72,10 @@ func main() {
 	data, err := json.MarshalIndent(output, "", "  ")
 	if err != nil {
 		log.Fatalf("Failed to marshal JSON: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*outputPath), 0755); err != nil {
+		log.Fatalf("Failed to create output directory: %v", err)
 	}
 
 	if err := os.WriteFile(*outputPath, data, 0644); err != nil {


### PR DESCRIPTION
The publish workflow writes to `web/data.json`, but `web/` doesn't exist in the
repo -- `os.WriteFile` fails on the missing parent directory. Add `os.MkdirAll`
before the write so the CLI creates any missing directories itself.

Fixes CI failure from #229.