### PR TITLE
feat: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,11 +10,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:
@@ -33,7 +34,15 @@ jobs:
         run: go vet ./...
 
       - name: Test
-        run: go test ./...
+        run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          flags: unit-tests
+          files: ./coverage.out
+          fail_ci_if_error: false
 
       - name: Build
         run: go build ./cmd/review-rot

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
         run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
           flags: unit-tests


### PR DESCRIPTION
## Summary
- Add `-coverprofile=coverage.out -covermode=atomic` to `go test` command
- Wire up `codecov-action` to upload coverage using OIDC authentication
- Uses `unit-tests` flag for coverage categorization
- No secret needed — OIDC handles auth for public repos

## Test plan
- [ ] CI workflow passes with coverage generation and upload
- [ ] Coverage data appears at https://app.codecov.io/gh/conforma/review-rot
- [ ] `unit-tests` flag visible in Codecov Flags tab

Ref: COVERPORT-209