### PR TITLE
fix: use Codecov token for initial repo activation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
-          use_oidc: true
+          token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit-tests
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Switch from OIDC to token-based Codecov upload to activate the repo
- OIDC uploads fail with "Repository not found" because the repo hasn't been registered in Codecov yet
- A token-based upload is needed for the initial activation

## Follow-up
After this merges and the first upload succeeds, revert back to `use_oidc: true` and remove the `CODECOV_TOKEN` repository secret.

Ref: COVERPORT-209