### PR TITLE
fix: add Codecov slug and revert to OIDC auth

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,8 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
+          slug: conforma/review-rot
           flags: unit-tests
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Revert from token-based auth back to OIDC
- Add explicit `slug: conforma/review-rot` so Codecov can identify the repo correctly
- The "Repository not found" error was likely caused by Codecov not resolving the repo name — the slug should fix this

## Follow-up
After merging, delete the `CODECOV_TOKEN` repository secret — it's no longer needed.

Ref: COVERPORT-209