### PR TITLE
fix: use Codecov token instead of OIDC for coverage upload

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -40,9 +39,9 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
-          use_oidc: true
-          slug: conforma/review-rot
           flags: unit-tests
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Switch from OIDC to token-based Codecov auth, matching the pattern used in conforma/cli
- OIDC uploads fail with "Repository not found" — Codecov's setup wizard doesn't complete activation for this repo
- Token is passed via `env` (not `with`), consistent with how cli does it
- Removed `id-token: write` permission since it's no longer needed

## Prerequisites
- `CODECOV_TOKEN` repository secret must be set (already done)

Ref: COVERPORT-209