### PR TITLE
fix: switch Codecov auth from token to OIDC

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
@@ -39,9 +40,8 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
+          use_oidc: true
           flags: unit-tests
           files: ./coverage.out
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Switch from token-based auth to OIDC (no secret needed)
- Add `id-token: write` permission required for OIDC
- Matches the pattern used in conforma/policy, conforma/go-gather, and conforma/crds

## Follow-up
After merging, delete the `CODECOV_TOKEN` repository secret:
```
gh secret delete CODECOV_TOKEN --repo conforma/review-rot
```

Ref: COVERPORT-209