### PR TITLE
Set gh-pages deploy author to github-actions[bot]

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -49,3 +49,5 @@ jobs:
         with:
           folder: web
           branch: gh-pages
+          git-config-name: "github-actions[bot]"
+          git-config-email: "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
Deploy commits on gh-pages were authored as lcarva, inherited from whoever
created the branch. Set git-config-name and git-config-email on the
JamesIves/github-pages-deploy-action so commits show github-actions[bot].