### PR TITLE
Exclude PR author's own reviews from review count

### DIFF
--- a/internal/github/query.go
+++ b/internal/github/query.go
@@ -62,6 +62,7 @@ type prNode struct {
 		Nodes []struct {
 			Author struct {
 				TypeName string `graphql:"__typename"`
+				Login    string
 			} `graphql:"author"`
 			Commit struct {
 				OID string `graphql:"oid"`
@@ -166,6 +167,9 @@ func extractReviews(node prNode) model.Reviews {
 	var lastHumanReviewOID string
 	for _, review := range node.Reviews.Nodes {
 		if review.Author.TypeName == "Bot" {
+			continue
+		}
+		if review.Author.Login == node.Author.Login {
 			continue
 		}
 		r.Count++

--- a/internal/github/query_test.go
+++ b/internal/github/query_test.go
@@ -85,9 +85,10 @@ func TestExtractSize(t *testing.T) {
 	}
 }
 
-func makeReviewNode(authorType, oid string) struct {
+func makeReviewNode(authorType, login, oid string) struct {
 	Author struct {
 		TypeName string `graphql:"__typename"`
+		Login    string
 	} `graphql:"author"`
 	Commit struct {
 		OID string `graphql:"oid"`
@@ -96,22 +97,25 @@ func makeReviewNode(authorType, oid string) struct {
 	var n struct {
 		Author struct {
 			TypeName string `graphql:"__typename"`
+			Login    string
 		} `graphql:"author"`
 		Commit struct {
 			OID string `graphql:"oid"`
 		}
 	}
 	n.Author.TypeName = authorType
+	n.Author.Login = login
 	n.Commit.OID = oid
 	return n
 }
 
 func TestExtractReviews(t *testing.T) {
 	node := prNode{HeadRefOid: "abc123"}
+	node.Author.Login = "author"
 	node.Reviews.Nodes = append(node.Reviews.Nodes,
-		makeReviewNode("User", "aaa"),
-		makeReviewNode("User", "bbb"),
-		makeReviewNode("User", "def456"),
+		makeReviewNode("User", "reviewer", "aaa"),
+		makeReviewNode("User", "reviewer", "bbb"),
+		makeReviewNode("User", "reviewer", "def456"),
 	)
 
 	r := extractReviews(node)
@@ -122,7 +126,7 @@ func TestExtractReviews(t *testing.T) {
 		t.Error("HasNewCommits should be true when last review OID differs from head")
 	}
 
-	node.Reviews.Nodes[2] = makeReviewNode("User", "abc123")
+	node.Reviews.Nodes[2] = makeReviewNode("User", "reviewer", "abc123")
 	r = extractReviews(node)
 	if r.HasNewCommits {
 		t.Error("HasNewCommits should be false when last review OID matches head")
@@ -139,10 +143,11 @@ func TestExtractReviewsZero(t *testing.T) {
 
 func TestExtractReviewsExcludesBots(t *testing.T) {
 	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
 	node.Reviews.Nodes = append(node.Reviews.Nodes,
-		makeReviewNode("User", "aaa"),
-		makeReviewNode("Bot", "bbb"),
-		makeReviewNode("Bot", "head"),
+		makeReviewNode("User", "reviewer", "aaa"),
+		makeReviewNode("Bot", "botuser", "bbb"),
+		makeReviewNode("Bot", "botuser", "head"),
 	)
 
 	r := extractReviews(node)
@@ -154,8 +159,8 @@ func TestExtractReviewsExcludesBots(t *testing.T) {
 	}
 
 	node.Reviews.Nodes = append(node.Reviews.Nodes[:0],
-		makeReviewNode("User", "head"),
-		makeReviewNode("Bot", "other"),
+		makeReviewNode("User", "reviewer", "head"),
+		makeReviewNode("Bot", "botuser", "other"),
 	)
 	r = extractReviews(node)
 	if r.Count != 1 {
@@ -168,9 +173,10 @@ func TestExtractReviewsExcludesBots(t *testing.T) {
 
 func TestExtractReviewsOnlyBots(t *testing.T) {
 	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
 	node.Reviews.Nodes = append(node.Reviews.Nodes,
-		makeReviewNode("Bot", "head"),
-		makeReviewNode("Bot", "old"),
+		makeReviewNode("Bot", "botuser", "head"),
+		makeReviewNode("Bot", "botuser", "old"),
 	)
 
 	r := extractReviews(node)
@@ -179,6 +185,50 @@ func TestExtractReviewsOnlyBots(t *testing.T) {
 	}
 	if r.HasNewCommits {
 		t.Error("HasNewCommits should be false when there are no human reviews")
+	}
+}
+
+func TestExtractReviewsExcludesPRAuthor(t *testing.T) {
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("User", "author", "head"),
+		makeReviewNode("User", "author", "old"),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 0 {
+		t.Errorf("Count = %d, want 0 (PR author reviews excluded)", r.Count)
+	}
+	if r.HasNewCommits {
+		t.Error("HasNewCommits should be false when there are no peer reviews")
+	}
+}
+
+func TestExtractReviewsAuthorAndBotsMixed(t *testing.T) {
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("Bot", "fullsend", "head"),
+		makeReviewNode("User", "author", "head"),
+		makeReviewNode("Bot", "coderabbit", "old"),
+		makeReviewNode("User", "author", "old"),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 0 {
+		t.Errorf("Count = %d, want 0 (only bot and PR author reviews)", r.Count)
+	}
+
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("User", "teammate", "head"),
+	)
+	r = extractReviews(node)
+	if r.Count != 1 {
+		t.Errorf("Count = %d, want 1 (one peer review)", r.Count)
+	}
+	if r.HasNewCommits {
+		t.Error("HasNewCommits should be false: peer review matches head")
 	}
 }
 


### PR DESCRIPTION
PR authors responding to bot feedback (e.g. fullsend, coderabbit) generate
COMMENTED reviews that get counted as peer reviews. A PR with only bot
reviews and author self-comments appears as fully reviewed on the dashboard
when no team member has actually looked at it.

Add `Login` to the review author GraphQL query and skip reviews where the
reviewer matches the PR author.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>