### PR TITLE
Include PR comments in review count

### DIFF
--- a/internal/github/query.go
+++ b/internal/github/query.go
@@ -51,6 +51,7 @@ type prNode struct {
 	Commits struct {
 		Nodes []struct {
 			Commit struct {
+				CommittedDate time.Time
 				StatusCheckRollup *struct {
 					State string
 				}
@@ -69,6 +70,16 @@ type prNode struct {
 			}
 		}
 	} `graphql:"reviews(last: 100, states: [APPROVED, CHANGES_REQUESTED, COMMENTED])"`
+
+	Comments struct {
+		Nodes []struct {
+			Author struct {
+				TypeName string `graphql:"__typename"`
+				Login    string
+			} `graphql:"author"`
+			CreatedAt time.Time
+		}
+	} `graphql:"comments(last: 100)"`
 
 	ReviewThreads struct {
 		Nodes []struct {
@@ -175,8 +186,24 @@ func extractReviews(node prNode) model.Reviews {
 		r.Count++
 		lastHumanReviewOID = review.Commit.OID
 	}
+	var lastHumanCommentAt time.Time
+	for _, comment := range node.Comments.Nodes {
+		if comment.Author.TypeName == "Bot" {
+			continue
+		}
+		if comment.Author.Login == node.Author.Login {
+			continue
+		}
+		r.Count++
+		if comment.CreatedAt.After(lastHumanCommentAt) {
+			lastHumanCommentAt = comment.CreatedAt
+		}
+	}
 	if r.Count > 0 {
-		r.HasNewCommits = lastHumanReviewOID != node.HeadRefOid
+		reviewCoversHead := lastHumanReviewOID == node.HeadRefOid
+		commentCoversHead := !lastHumanCommentAt.IsZero() && len(node.Commits.Nodes) > 0 &&
+			!lastHumanCommentAt.Before(node.Commits.Nodes[0].Commit.CommittedDate)
+		r.HasNewCommits = !reviewCoversHead && !commentCoversHead
 	}
 	return r
 }

--- a/internal/github/query.go
+++ b/internal/github/query.go
@@ -176,6 +176,7 @@ func extractSize(node prNode) *string {
 func extractReviews(node prNode) model.Reviews {
 	var r model.Reviews
 	var lastHumanReviewOID string
+	seen := make(map[string]struct{})
 	for _, review := range node.Reviews.Nodes {
 		if review.Author.TypeName == "Bot" {
 			continue
@@ -183,7 +184,7 @@ func extractReviews(node prNode) model.Reviews {
 		if review.Author.Login == node.Author.Login {
 			continue
 		}
-		r.Count++
+		seen[review.Author.Login] = struct{}{}
 		lastHumanReviewOID = review.Commit.OID
 	}
 	var lastHumanCommentAt time.Time
@@ -194,11 +195,12 @@ func extractReviews(node prNode) model.Reviews {
 		if comment.Author.Login == node.Author.Login {
 			continue
 		}
-		r.Count++
+		seen[comment.Author.Login] = struct{}{}
 		if comment.CreatedAt.After(lastHumanCommentAt) {
 			lastHumanCommentAt = comment.CreatedAt
 		}
 	}
+	r.Count = len(seen)
 	if r.Count > 0 {
 		reviewCoversHead := lastHumanReviewOID == node.HeadRefOid
 		commentCoversHead := !lastHumanCommentAt.IsZero() && len(node.Commits.Nodes) > 0 &&

--- a/internal/github/query_test.go
+++ b/internal/github/query_test.go
@@ -17,10 +17,12 @@ func TestExtractCIStatusSuccess(t *testing.T) {
 	node := prNode{}
 	node.Commits.Nodes = []struct {
 		Commit struct {
+			CommittedDate     time.Time
 			StatusCheckRollup *struct{ State string }
 		}
 	}{
 		{Commit: struct {
+			CommittedDate     time.Time
 			StatusCheckRollup *struct{ State string }
 		}{StatusCheckRollup: &struct{ State string }{State: "SUCCESS"}}},
 	}
@@ -35,10 +37,12 @@ func TestExtractCIStatusNull(t *testing.T) {
 	node := prNode{}
 	node.Commits.Nodes = []struct {
 		Commit struct {
+			CommittedDate     time.Time
 			StatusCheckRollup *struct{ State string }
 		}
 	}{
 		{Commit: struct {
+			CommittedDate     time.Time
 			StatusCheckRollup *struct{ State string }
 		}{StatusCheckRollup: nil}},
 	}
@@ -107,6 +111,40 @@ func makeReviewNode(authorType, login, oid string) struct {
 	n.Author.Login = login
 	n.Commit.OID = oid
 	return n
+}
+
+func makeCommentNode(authorType, login string, createdAt time.Time) struct {
+	Author struct {
+		TypeName string `graphql:"__typename"`
+		Login    string
+	} `graphql:"author"`
+	CreatedAt time.Time
+} {
+	var n struct {
+		Author struct {
+			TypeName string `graphql:"__typename"`
+			Login    string
+		} `graphql:"author"`
+		CreatedAt time.Time
+	}
+	n.Author.TypeName = authorType
+	n.Author.Login = login
+	n.CreatedAt = createdAt
+	return n
+}
+
+func setHeadCommitDate(node *prNode, t time.Time) {
+	node.Commits.Nodes = []struct {
+		Commit struct {
+			CommittedDate     time.Time
+			StatusCheckRollup *struct{ State string }
+		}
+	}{
+		{Commit: struct {
+			CommittedDate     time.Time
+			StatusCheckRollup *struct{ State string }
+		}{CommittedDate: t}},
+	}
 }
 
 func TestExtractReviews(t *testing.T) {
@@ -322,6 +360,154 @@ func TestTransformPRBotAuthor(t *testing.T) {
 	pr := transformPR(node, "conforma/policy")
 	if !pr.IsAutomated {
 		t.Error("IsAutomated should be true for Bot author")
+	}
+}
+
+func TestExtractReviewsCountsComments(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 1 {
+		t.Errorf("Count = %d, want 1 (one human comment)", r.Count)
+	}
+}
+
+func TestExtractReviewsCommentsExcludesBots(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer", commentDate),
+		makeCommentNode("Bot", "codecov", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 1 {
+		t.Errorf("Count = %d, want 1 (bot comment excluded)", r.Count)
+	}
+}
+
+func TestExtractReviewsCommentsExcludesAuthor(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "author", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 0 {
+		t.Errorf("Count = %d, want 0 (PR author comment excluded)", r.Count)
+	}
+}
+
+func TestExtractReviewsMixedReviewsAndComments(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("User", "reviewer-a", "head"),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer-b", commentDate),
+		makeCommentNode("Bot", "ci-bot", commentDate),
+		makeCommentNode("User", "author", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 2 {
+		t.Errorf("Count = %d, want 2 (1 review + 1 human comment)", r.Count)
+	}
+}
+
+func TestExtractReviewsCommentAfterHeadCommit(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.HasNewCommits {
+		t.Error("HasNewCommits should be false: comment was posted after HEAD commit")
+	}
+}
+
+func TestExtractReviewsCommentBeforeHeadCommit(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 14, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer", commentDate),
+	)
+
+	r := extractReviews(node)
+	if !r.HasNewCommits {
+		t.Error("HasNewCommits should be true: comment was posted before HEAD commit")
+	}
+}
+
+func TestExtractReviewsCommentCoversHeadDespiteStaleReview(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("User", "reviewer", "old-commit"),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.HasNewCommits {
+		t.Error("HasNewCommits should be false: comment covers HEAD even though review is stale")
+	}
+}
+
+func TestExtractReviewsReviewCoversHeadDespiteStaleComment(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 14, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("User", "reviewer", "head"),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "reviewer", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.HasNewCommits {
+		t.Error("HasNewCommits should be false: review covers HEAD even though comment is stale")
 	}
 }
 

--- a/internal/github/query_test.go
+++ b/internal/github/query_test.go
@@ -157,8 +157,8 @@ func TestExtractReviews(t *testing.T) {
 	)
 
 	r := extractReviews(node)
-	if r.Count != 3 {
-		t.Errorf("Count = %d, want 3", r.Count)
+	if r.Count != 1 {
+		t.Errorf("Count = %d, want 1 (deduplicated by author)", r.Count)
 	}
 	if !r.HasNewCommits {
 		t.Error("HasNewCommits should be true when last review OID differs from head")
@@ -508,6 +508,30 @@ func TestExtractReviewsReviewCoversHeadDespiteStaleComment(t *testing.T) {
 	r := extractReviews(node)
 	if r.HasNewCommits {
 		t.Error("HasNewCommits should be false: review covers HEAD even though comment is stale")
+	}
+}
+
+func TestExtractReviewsDeduplicatesByAuthor(t *testing.T) {
+	commitDate := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
+	commentDate := time.Date(2025, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	node := prNode{HeadRefOid: "head"}
+	node.Author.Login = "author"
+	setHeadCommitDate(&node, commitDate)
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeReviewNode("User", "alice", "head"),
+		makeReviewNode("User", "alice", "old"),
+		makeReviewNode("User", "bob", "head"),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeCommentNode("User", "alice", commentDate),
+		makeCommentNode("User", "bob", commentDate),
+		makeCommentNode("User", "charlie", commentDate),
+	)
+
+	r := extractReviews(node)
+	if r.Count != 3 {
+		t.Errorf("Count = %d, want 3 (alice, bob, charlie)", r.Count)
 	}
 }
 


### PR DESCRIPTION
Only formal PR reviews were counted. Regular PR comments from humans were ignored, so PRs like cli#3426 showed 0 reviews despite having comment-based feedback from simonbaird.

Add `comments(last: 100)` to the GraphQL query and count non-bot, non-author comments alongside formal reviews. For `HasNewCommits`, compare the latest human comment's `createdAt` against the HEAD commit's `committedDate`. A comment that post-dates the commit counts as covering it, same as a review on the HEAD OID.