### PR TITLE
Add reviewer leaderboard tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ review-rot is a PR dashboard. It has three components:
 ```text
 cmd/review-rot/main.go       — CLI entry point
 internal/config/              — YAML config parsing (sources + UI)
-internal/github/              — GitHub API: auth, repo discovery, PR queries, filtering
+internal/github/              — GitHub API: auth, repo discovery, PR queries, filtering, leaderboard
 internal/model/               — Output data model (Go structs with JSON tags)
 frontend/index.html           — Dashboard HTML
 frontend/css/style.css        — Styles
@@ -57,6 +57,12 @@ secret, passed as the `GITHUB_PRIVATE_KEY` environment variable.
   PRs from other orgs only included if author is in the `authors` list
 - Bot detection: PRs from authors in the `bots` list are flagged as automated
 - Frontend uses vanilla JS with no dependencies or build step
+- Reviewer leaderboard aggregates review/comment activity across PRs of any
+  state within a configurable data horizon; the backend emits each reviewer's
+  PR list with per-PR author and engagement timestamp. The frontend shows it in
+  a separate tab with a client-side interval slider (0..horizon, narrows and
+  re-ranks) and per-row accordions that open a table (PR/repo/author/reviewed
+  date) of the PRs behind each count
 - Data refreshed every 30 minutes on weekdays via GitHub Actions cron
 - Dashboard appearance (title, logo, colors) is configured via `config/ui.yaml`
   and injected into `data.json` as `ui_settings`; the frontend applies them at
@@ -81,6 +87,9 @@ See `config/sources.yaml` for the full backend configuration. Key sections:
 - `sources.repos` — explicit repos to monitor
 - `authors` — team members for pre-filtering
 - `bots` — bot accounts to flag as automated
+- `leaderboard.window_days` — data horizon: days of review history to aggregate
+  for the reviewer leaderboard (default 90). The frontend interval selector
+  narrows this further client-side, so it is the widest range shown
 
 See `config/ui.yaml` for appearance settings:
 - `title` — dashboard title (shown in header and browser tab)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Live example: **[conforma.dev/review-rot](https://conforma.dev/review-rot/)**
 ## How it works
 
 A Go CLI queries the GitHub GraphQL API for open PRs across configured repos,
-enriches each with review/CI/conversation metadata, and outputs `data.json`. A
-static frontend (vanilla JS + CSS) renders the data with client-side filtering
-and sorting.
+enriches each with review/CI/conversation metadata, and outputs `data.json`. It
+also aggregates recent review activity into a reviewer leaderboard. A static
+frontend (vanilla JS + CSS) renders the data with client-side filtering and
+sorting, split across a Pull Requests tab and a Leaderboard tab.
 
 ## Deployment
 
@@ -33,8 +34,21 @@ reads it from the `EC_AUTOMATION_KEY` secret.
 The `config/` directory contains two files:
 
 - **`sources.yaml`** — GitHub App credentials, monitored orgs/repos, team
-  members, and bot accounts. See the comments in that file for details.
+  members, and the reviewer-leaderboard data horizon (`leaderboard.window_days`,
+  default 90). See the comments in that file for details.
 - **`ui.yaml`** — Dashboard appearance: title, logo, and accent colors.
+
+The **Leaderboard** tab ranks people by the number of distinct PRs they reviewed
+or commented on across the monitored repos. It counts activity on PRs of any
+state (open, merged, or closed) and excludes bots and self-reviews, matching the
+reviewer count shown on the PR list.
+
+`leaderboard.window_days` is the data horizon — the widest range the backend
+aggregates. The tab has an interval slider (0 to the horizon, with preset
+shortcuts like 7d / 30d / 90d) that narrows the window client-side, re-counting
+and re-ranking without a rebuild. Each row is an accordion: clicking it opens a
+table of the PRs behind that person's count — PR title, repo, author, and review
+date — sorted most recent first.
 
 ## GitHub App
 

--- a/cmd/review-rot/main.go
+++ b/cmd/review-rot/main.go
@@ -61,10 +61,22 @@ func main() {
 		filtered = []model.PullRequest{}
 	}
 
+	since := time.Now().UTC().AddDate(0, 0, -cfg.Leaderboard.WindowDays)
+	reviewsByPerson := make(map[string][]model.ReviewedPR)
+	for _, repo := range repos {
+		if err := gh.FetchRepoReviewerActivity(ctx, client, repo, since, reviewsByPerson); err != nil {
+			log.Printf("Warning: failed to fetch reviewer activity for %s: %v", repo, err)
+			continue
+		}
+	}
+	leaderboard := gh.BuildLeaderboard(reviewsByPerson, cfg.Leaderboard.WindowDays, since)
+	log.Printf("Leaderboard: %d reviewers over the last %d days", len(leaderboard.Reviewers), cfg.Leaderboard.WindowDays)
+
 	output := model.Output{
 		GeneratedAt:  time.Now().UTC(),
 		UISettings:   model.NewUISettings(cfg.UI.Title, cfg.UI.Logo, cfg.UI.Favicon, cfg.UI.Palette.Accent, cfg.UI.Palette.AccentDark, cfg.UI.Palette.AccentLight),
 		PullRequests: filtered,
+		Leaderboard:  leaderboard,
 	}
 
 	data, err := json.MarshalIndent(output, "", "  ")

--- a/config/sources.yaml
+++ b/config/sources.yaml
@@ -25,6 +25,13 @@ sources:
     - tektoncd/chains
     - release-engineering/rhtap-ec-policy
 
+# Reviewer leaderboard settings
+leaderboard:
+  # Data horizon: how many days of review history to aggregate. This is the
+  # widest range the leaderboard can show; the dashboard's interval selector
+  # narrows it further client-side. Defaults to 90 if omitted.
+  window_days: 90
+
 # Team members — PRs from these authors are always shown,
 # even in repos outside the orgs above
 authors:

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -440,3 +440,324 @@ select:focus {
     color: var(--text-secondary);
     font-size: var(--font-size-sm);
 }
+
+.view-tabs {
+    display: flex;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-sm) var(--spacing-md) 0;
+    background: var(--bg);
+    border-bottom: 2px solid var(--accent-light);
+}
+
+.view-tab {
+    padding: var(--spacing-sm) var(--spacing-md);
+    border: 1px solid var(--border);
+    border-bottom: none;
+    border-radius: var(--radius) var(--radius) 0 0;
+    background: var(--bg-secondary);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: var(--font-size-base);
+    font-family: var(--font-family);
+    font-weight: 500;
+    transition: background 0.15s, color 0.15s;
+}
+
+.view-tab:hover {
+    background: var(--accent-light);
+    color: var(--accent-dark);
+}
+
+.view-tab.active {
+    background: var(--accent);
+    color: #fff;
+    border-color: var(--accent);
+}
+
+.leaderboard-header {
+    padding: var(--spacing-md) var(--spacing-md) 0;
+}
+
+.leaderboard-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    flex-wrap: wrap;
+}
+
+.leaderboard-header h2 {
+    font-size: var(--font-size-lg);
+    font-weight: 600;
+    color: var(--accent-dark);
+}
+
+.leaderboard-subtitle {
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    margin-top: 2px;
+}
+
+.leaderboard-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.leaderboard-table th {
+    text-align: left;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--accent-dark);
+    background: var(--accent-light);
+    border-bottom: 2px solid var(--accent-light);
+    position: sticky;
+    top: 0;
+}
+
+.leaderboard-table td {
+    padding: var(--spacing-sm);
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+    font-size: var(--font-size-base);
+}
+
+.leaderboard-table tbody tr:hover {
+    background: var(--bg-hover);
+}
+
+.leaderboard-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.lb-rank-head {
+    width: 48px;
+    text-align: center;
+}
+
+.lb-rank {
+    width: 48px;
+    text-align: center;
+    font-weight: 600;
+    font-size: var(--font-size-lg);
+}
+
+.lb-reviewer a {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.lb-reviewer a:hover {
+    text-decoration: underline;
+    color: var(--accent-dark);
+}
+
+/* Column widths: rank fixed, PRs-reviewed takes two thirds, reviewer the rest. */
+.lb-col-rank {
+    width: 56px;
+}
+
+.lb-col-count {
+    width: 66%;
+}
+
+.leaderboard-table td {
+    vertical-align: middle;
+}
+
+.lb-reviewer-inner {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+}
+
+.lb-reviewer .avatar-sm {
+    width: 24px;
+    height: 24px;
+}
+
+.lb-count-inner {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+}
+
+.lb-meter {
+    flex: 1;
+    height: 14px;
+    background: rgba(36, 95, 136, 0.12);
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+/* Flat Material fill; grows from 0 to its value on (re)render. */
+.lb-meter-fill {
+    display: block;
+    height: 100%;
+    min-width: 3px;
+    width: var(--lb-w, 0);
+    border-radius: 4px;
+    background: #245f88;
+    animation: lb-grow 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@keyframes lb-grow {
+    from { width: 0; }
+    to { width: var(--lb-w, 0); }
+}
+
+/* Podium colors for the top three. */
+.lb-meter-fill.rank-1 { background: #fabc09; }
+.lb-meter-fill.rank-2 { background: #ace2ff; }
+.lb-meter-fill.rank-3 { background: #f1511b; }
+
+.lb-count-value {
+    min-width: 2ch;
+    text-align: right;
+    font-weight: 600;
+    font-size: var(--font-size-lg);
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .lb-meter-fill { animation: none; }
+}
+
+.lb-row {
+    cursor: pointer;
+}
+
+.lb-row:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+}
+
+.lb-chevron {
+    display: inline-block;
+    font-size: 10px;
+    color: var(--text-secondary);
+    transition: transform 0.15s;
+    flex-shrink: 0;
+}
+
+.lb-row.expanded .lb-chevron {
+    transform: rotate(90deg);
+}
+
+.lb-detail-cell {
+    padding: 0 0 0 40px !important;
+    background: var(--bg-secondary);
+}
+
+.lb-pr-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-size-sm);
+}
+
+.lb-pr-table th {
+    text-align: left;
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    border-bottom: 1px solid var(--border);
+    background: transparent;
+}
+
+.lb-pr-table td {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+}
+
+.lb-pr-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.lb-pr-table a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.lb-pr-table a:hover {
+    text-decoration: underline;
+    color: var(--accent-dark);
+}
+
+.lb-pr-title {
+    width: 45%;
+}
+
+.lb-pr-repo,
+.lb-pr-author {
+    color: var(--text-secondary);
+    white-space: nowrap;
+}
+
+.lb-pr-date {
+    white-space: nowrap;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+}
+
+/* Interval slider */
+.lb-interval-group {
+    gap: var(--spacing-md);
+}
+
+.lb-slider {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+}
+
+.lb-slider-value {
+    min-width: 56px;
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    color: var(--accent-dark);
+    font-variant-numeric: tabular-nums;
+}
+
+input[type="range"]#lb-interval-slider {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 180px;
+    height: 6px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--accent) 0%, var(--accent) var(--lb-slider-pct, 100%), var(--accent-light) var(--lb-slider-pct, 100%), var(--accent-light) 100%);
+    cursor: pointer;
+    outline: none;
+}
+
+#lb-interval-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 2px solid #fff;
+    box-shadow: 0 0 4px rgba(90, 125, 154, 0.6);
+    cursor: pointer;
+}
+
+#lb-interval-slider::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--accent);
+    border: 2px solid #fff;
+    box-shadow: 0 0 4px rgba(90, 125, 154, 0.6);
+    cursor: pointer;
+}
+
+#lb-interval-slider:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,57 +28,102 @@
         </div>
     </header>
 
-    <div class="filters">
-        <div class="filter-group">
-            <label class="toggle-label" title="Show only PRs that are not drafts, have passing CI, and have unreviewed changes">
-                <input type="checkbox" id="ready-filter">
-                <span>Ready for review</span>
-            </label>
-        </div>
-        <div class="filter-group">
-            <label class="filter-label">Type</label>
-            <div class="type-buttons" id="type-filter">
-                <button class="type-btn active" data-type="regular">Regular</button>
-                <button class="type-btn" data-type="automated">Automated</button>
-                <button class="type-btn" data-type="wip">WIP</button>
-                <button class="type-btn" data-type="all">All</button>
+    <nav class="view-tabs" id="view-tabs">
+        <button class="view-tab active" data-view="prs">Pull Requests</button>
+        <button class="view-tab" data-view="leaderboard">Leaderboard</button>
+    </nav>
+
+    <div id="prs-view">
+        <div class="filters">
+            <div class="filter-group">
+                <label class="toggle-label" title="Show only PRs that are not drafts, have passing CI, and have unreviewed changes">
+                    <input type="checkbox" id="ready-filter">
+                    <span>Ready for review</span>
+                </label>
+            </div>
+            <div class="filter-group">
+                <label class="filter-label">Type</label>
+                <div class="type-buttons" id="type-filter">
+                    <button class="type-btn active" data-type="regular">Regular</button>
+                    <button class="type-btn" data-type="automated">Automated</button>
+                    <button class="type-btn" data-type="wip">WIP</button>
+                    <button class="type-btn" data-type="all">All</button>
+                </div>
+            </div>
+            <div class="filter-group">
+                <label class="filter-label" for="author-filter">Author</label>
+                <select id="author-filter">
+                    <option value="all">All authors</option>
+                </select>
+            </div>
+            <div class="filter-group">
+                <label class="filter-label" for="repo-filter">Repository</label>
+                <select id="repo-filter">
+                    <option value="all">All repos</option>
+                </select>
             </div>
         </div>
-        <div class="filter-group">
-            <label class="filter-label" for="author-filter">Author</label>
-            <select id="author-filter">
-                <option value="all">All authors</option>
-            </select>
+
+        <div class="table-container">
+            <table class="pr-table">
+                <thead>
+                    <tr>
+                        <th class="sortable" data-sort="title">PR</th>
+                        <th class="sortable" data-sort="ci_status">CI</th>
+                        <th class="sortable" data-sort="updated_at"><span class="col-tooltip-wrap">Updated <span class="col-tooltip" title="Time since last activity">?</span></span></th>
+                        <th class="sortable" data-sort="created_at"><span class="col-tooltip-wrap">Age <span class="col-tooltip" title="Time since PR was created">?</span></span></th>
+                        <th class="sortable" data-sort="threads">Unresolved <span class="col-tooltip-wrap">threads <span class="col-tooltip" title="Unresolved review threads">?</span></span></th>
+                        <th class="sortable" data-sort="reviews"><span class="col-tooltip-wrap">Reviews <span class="col-tooltip" title="Number of completed reviews">?</span></span></th>
+                        <th class="sortable" data-sort="re_review">Unreviewed <span class="col-tooltip-wrap">changes <span class="col-tooltip" title="PR has no reviews yet, or new commits were pushed since the last review">?</span></span></th>
+                    </tr>
+                </thead>
+                <tbody id="pr-table-body">
+                </tbody>
+            </table>
         </div>
-        <div class="filter-group">
-            <label class="filter-label" for="repo-filter">Repository</label>
-            <select id="repo-filter">
-                <option value="all">All repos</option>
-            </select>
+
+        <div id="empty-state" class="empty-state" hidden>
+            No pull requests match the current filters.
         </div>
     </div>
 
-    <div class="table-container">
-        <table class="pr-table">
-            <thead>
-                <tr>
-                    <th class="sortable" data-sort="title">PR</th>
-                    <th class="sortable" data-sort="ci_status">CI</th>
-                    <th class="sortable" data-sort="updated_at"><span class="col-tooltip-wrap">Updated <span class="col-tooltip" title="Time since last activity">?</span></span></th>
-                    <th class="sortable" data-sort="created_at"><span class="col-tooltip-wrap">Age <span class="col-tooltip" title="Time since PR was created">?</span></span></th>
-                    <th class="sortable" data-sort="threads">Unresolved <span class="col-tooltip-wrap">threads <span class="col-tooltip" title="Unresolved review threads">?</span></span></th>
-                    <th class="sortable" data-sort="reviews"><span class="col-tooltip-wrap">Reviews <span class="col-tooltip" title="Number of completed reviews">?</span></span></th>
-                    <th class="sortable" data-sort="re_review">Unreviewed <span class="col-tooltip-wrap">changes <span class="col-tooltip" title="PR has no reviews yet, or new commits were pushed since the last review">?</span></span></th>
-                </tr>
-            </thead>
-            <tbody id="pr-table-body">
-            </tbody>
-        </table>
-    </div>
-
-    <div id="empty-state" class="empty-state" hidden>
-        No pull requests match the current filters.
-    </div>
+    <section id="leaderboard-view" hidden>
+        <div class="leaderboard-header">
+            <div class="leaderboard-heading">
+                <h2>Reviewer leaderboard</h2>
+                <div class="filter-group lb-interval-group">
+                    <label class="filter-label" for="lb-interval-slider">Interval</label>
+                    <div class="lb-slider">
+                        <input type="range" id="lb-interval-slider" min="0" max="1" value="1" step="1">
+                        <output class="lb-slider-value" id="lb-interval-value" for="lb-interval-slider"></output>
+                    </div>
+                    <div class="type-buttons" id="lb-interval-presets"></div>
+                </div>
+            </div>
+            <p class="leaderboard-subtitle" id="leaderboard-subtitle"></p>
+        </div>
+        <div class="table-container">
+            <table class="leaderboard-table">
+                <colgroup>
+                    <col class="lb-col-rank">
+                    <col class="lb-col-reviewer">
+                    <col class="lb-col-count">
+                </colgroup>
+                <thead>
+                    <tr>
+                        <th class="lb-rank-head"></th>
+                        <th>Reviewer</th>
+                        <th><span class="col-tooltip-wrap">PRs reviewed <span class="col-tooltip" title="Distinct pull requests the person reviewed or commented on in the window">?</span></span></th>
+                    </tr>
+                </thead>
+                <tbody id="leaderboard-body">
+                </tbody>
+            </table>
+        </div>
+        <div id="leaderboard-empty" class="empty-state" hidden>
+            No reviewer activity in this window.
+        </div>
+    </section>
 
     <div id="error-banner" class="error-banner" hidden>
         Failed to load PR data. Try refreshing.

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -487,7 +487,7 @@ function buildIntervalSelector() {
     if (state.leaderboardDays == null) state.leaderboardDays = horizon;
     state.leaderboardDays = clampDays(state.leaderboardDays, horizon);
 
-    slider.min = 0;
+    slider.min = 1;
     slider.max = horizon;
     slider.value = state.leaderboardDays;
 
@@ -506,7 +506,7 @@ function buildIntervalSelector() {
 }
 
 function clampDays(days, horizon) {
-    return Math.max(0, Math.min(horizon, days));
+    return Math.max(1, Math.min(horizon, days));
 }
 
 function setLeaderboardInterval(days) {

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -1,6 +1,9 @@
 const state = {
     data: [],
+    leaderboard: null,
+    leaderboardDays: null,
     generatedAt: null,
+    view: 'prs',
     filters: {
         type: 'regular',
         author: 'all',
@@ -21,11 +24,15 @@ async function init() {
         if (!response.ok) throw new Error(`HTTP ${response.status}`);
         const json = await response.json();
         state.data = json.pull_requests || [];
+        state.leaderboard = json.leaderboard || null;
         state.generatedAt = json.generated_at;
         applyUISettings(json.ui_settings);
         populateFilters();
         initSortArrows();
         render();
+        buildIntervalSelector();
+        renderLeaderboard();
+        reflectView();
         updateFooter();
         attachEventListeners();
     } catch (err) {
@@ -89,6 +96,12 @@ function populateFilters() {
 function restoreFiltersFromURL() {
     const params = new URLSearchParams(window.location.search);
 
+    const view = params.get('view');
+    if (view === 'leaderboard') state.view = 'leaderboard';
+
+    const days = parseInt(params.get('days'), 10);
+    if (Number.isFinite(days) && days >= 0) state.leaderboardDays = days;
+
     if (params.get('ready') === '1') {
         state.filters.readyForReview = true;
         document.getElementById('ready-filter').checked = true;
@@ -125,6 +138,16 @@ function updateURL() {
         else p.delete(key);
     };
 
+    setOrDelete('view', state.view, 'prs');
+
+    // The horizon (full window) is the default, so it stays out of the URL.
+    const horizon = (state.leaderboard && state.leaderboard.window_days) || null;
+    if (state.leaderboardDays != null && state.leaderboardDays !== horizon) {
+        p.set('days', state.leaderboardDays);
+    } else {
+        p.delete('days');
+    }
+
     setOrDelete('type', state.filters.type, 'regular');
     setOrDelete('author', state.filters.author, 'all');
     setOrDelete('repo', state.filters.repo, 'all');
@@ -142,6 +165,27 @@ function updateURL() {
 }
 
 function attachEventListeners() {
+    document.querySelectorAll('.view-tab').forEach(btn => {
+        btn.addEventListener('click', () => {
+            setView(btn.dataset.view);
+        });
+    });
+
+    const lbBody = document.getElementById('leaderboard-body');
+    lbBody.addEventListener('click', (e) => {
+        if (e.target.closest('a')) return; // let profile / PR links work
+        const row = e.target.closest('.lb-row');
+        if (row) toggleLeaderboardRow(row);
+    });
+    lbBody.addEventListener('keydown', (e) => {
+        if (e.key !== 'Enter' && e.key !== ' ') return;
+        const row = e.target.closest('.lb-row');
+        if (row && e.target === row) {
+            e.preventDefault();
+            toggleLeaderboardRow(row);
+        }
+    });
+
     document.querySelectorAll('.type-btn').forEach(btn => {
         btn.addEventListener('click', () => {
             document.querySelectorAll('.type-btn').forEach(b => b.classList.remove('active'));
@@ -379,6 +423,220 @@ function render() {
     document.getElementById('avg-age').textContent = stats.count > 0 ? formatDuration(stats.avgAge) : '—';
 
     updateSortIndicators();
+}
+
+function setView(view) {
+    state.view = view;
+    reflectView();
+    updateURL();
+}
+
+function reflectView() {
+    const isLeaderboard = state.view === 'leaderboard';
+
+    document.querySelectorAll('.view-tab').forEach(b => {
+        b.classList.toggle('active', b.dataset.view === state.view);
+    });
+
+    document.getElementById('prs-view').hidden = isLeaderboard;
+    document.getElementById('leaderboard-view').hidden = !isLeaderboard;
+
+    // The header stats (PRs shown / avg age) only apply to the PR list.
+    const stats = document.querySelector('.stats');
+    if (stats) stats.style.visibility = isLeaderboard ? 'hidden' : 'visible';
+}
+
+// leaderboardForInterval re-counts and re-ranks reviewers for the given window
+// by keeping only the PRs each person engaged with since (generated_at - days).
+function leaderboardForInterval(days) {
+    const lb = state.leaderboard;
+    const reviewers = (lb && Array.isArray(lb.reviewers)) ? lb.reviewers : [];
+    const ref = state.generatedAt ? new Date(state.generatedAt).getTime() : Date.now();
+    const cutoff = ref - days * 86400000;
+
+    return reviewers
+        .map(r => {
+            const prs = (r.prs || []).filter(pr => {
+                const t = new Date(pr.engaged_at).getTime();
+                return !Number.isNaN(t) && t >= cutoff;
+            });
+            return { login: r.login || '', reviews: prs.length, prs };
+        })
+        .filter(r => r.reviews > 0)
+        .sort((a, b) => b.reviews - a.reviews || a.login.localeCompare(b.login));
+}
+
+// buildIntervalSelector wires up the day-window slider (0 .. horizon) plus the
+// preset shortcuts that snap it to common windows. The horizon is the backend's
+// window_days; the whole control is hidden when there is no usable horizon.
+function buildIntervalSelector() {
+    const slider = document.getElementById('lb-interval-slider');
+    const presetsEl = document.getElementById('lb-interval-presets');
+    if (!slider || !presetsEl) return;
+
+    const horizon = (state.leaderboard && state.leaderboard.window_days) || 0;
+    const group = slider.closest('.filter-group');
+
+    if (horizon <= 0) {
+        if (group) group.hidden = true;
+        if (state.leaderboardDays == null) state.leaderboardDays = 0;
+        return;
+    }
+    if (group) group.hidden = false;
+
+    if (state.leaderboardDays == null) state.leaderboardDays = horizon;
+    state.leaderboardDays = clampDays(state.leaderboardDays, horizon);
+
+    slider.min = 0;
+    slider.max = horizon;
+    slider.value = state.leaderboardDays;
+
+    // Presets that fit inside the horizon; the horizon itself is always offered.
+    const presets = [...new Set([7, 30, 90].filter(d => d < horizon)), horizon].sort((a, b) => a - b);
+    presetsEl.innerHTML = presets.map(d =>
+        `<button class="type-btn" data-days="${d}">${d}d</button>`
+    ).join('');
+    presetsEl.querySelectorAll('.type-btn').forEach(btn => {
+        btn.addEventListener('click', () => setLeaderboardInterval(Number(btn.dataset.days)));
+    });
+
+    slider.addEventListener('input', () => setLeaderboardInterval(Number(slider.value)));
+
+    updateIntervalUI();
+}
+
+function clampDays(days, horizon) {
+    return Math.max(0, Math.min(horizon, days));
+}
+
+function setLeaderboardInterval(days) {
+    const horizon = (state.leaderboard && state.leaderboard.window_days) || days;
+    state.leaderboardDays = clampDays(days, horizon);
+    updateIntervalUI();
+    renderLeaderboard();
+    updateURL();
+}
+
+// updateIntervalUI syncs the slider position, the "N days" readout, the filled
+// portion of the track, and which preset (if any) is currently active.
+function updateIntervalUI() {
+    const slider = document.getElementById('lb-interval-slider');
+    const valueEl = document.getElementById('lb-interval-value');
+    const days = state.leaderboardDays || 0;
+
+    if (slider && Number(slider.value) !== days) slider.value = days;
+    if (valueEl) valueEl.textContent = `${days} ${days === 1 ? 'day' : 'days'}`;
+
+    document.querySelectorAll('#lb-interval-presets .type-btn').forEach(b => {
+        b.classList.toggle('active', Number(b.dataset.days) === days);
+    });
+
+    if (slider) {
+        const max = Number(slider.max) || 1;
+        slider.style.setProperty('--lb-slider-pct', `${max > 0 ? (days / max) * 100 : 0}%`);
+    }
+}
+
+function toggleLeaderboardRow(row) {
+    const index = row.dataset.index;
+    const detail = document.getElementById(`lb-detail-${index}`);
+    if (!detail) return;
+    const expanded = row.getAttribute('aria-expanded') === 'true';
+    row.setAttribute('aria-expanded', String(!expanded));
+    row.classList.toggle('expanded', !expanded);
+    detail.hidden = expanded;
+}
+
+function renderLeaderboard() {
+    const subtitle = document.getElementById('leaderboard-subtitle');
+    const body = document.getElementById('leaderboard-body');
+    const empty = document.getElementById('leaderboard-empty');
+    const container = document.querySelector('#leaderboard-view .table-container');
+
+    const days = state.leaderboardDays || 0;
+    const reviewers = leaderboardForInterval(days);
+
+    subtitle.textContent = days > 0
+        ? `Distinct PRs each person reviewed or commented on across monitored repos in the last ${days} days`
+        : '';
+
+    if (reviewers.length === 0) {
+        body.innerHTML = '';
+        container.hidden = true;
+        empty.hidden = false;
+        return;
+    }
+
+    container.hidden = false;
+    empty.hidden = true;
+
+    const max = reviewers[0].reviews || 1;
+    body.innerHTML = reviewers.map((r, i) => renderLeaderboardRow(r, i, max)).join('');
+}
+
+function renderLeaderboardRow(reviewer, index, max) {
+    const login = reviewer.login || '';
+    const reviews = reviewer.reviews || 0;
+    const rank = index + 1;
+    const rankCell = rank === 1 ? '\u{1F947}' : rank === 2 ? '\u{1F948}' : rank === 3 ? '\u{1F949}' : String(rank);
+    const pct = max > 0 ? Math.round((reviews / max) * 100) : 0;
+    const profile = `https://github.com/${encodeURIComponent(login)}`;
+    const avatar = `${profile}.png?size=40`;
+
+    const rankClass = rank <= 3 ? ` rank-${rank}` : '';
+    const mainRow = `<tr class="lb-row" data-index="${index}" tabindex="0" role="button" aria-expanded="false" aria-controls="lb-detail-${index}">
+        <td class="lb-rank">${rankCell}</td>
+        <td class="lb-reviewer">
+            <div class="lb-reviewer-inner">
+                <span class="lb-chevron" aria-hidden="true">&#x25B6;</span>
+                <img class="avatar-sm" src="${escapeHtml(avatar)}" alt="" width="24" height="24">
+                <a href="${escapeHtml(profile)}" target="_blank" rel="noopener">${escapeHtml(login)}</a>
+            </div>
+        </td>
+        <td class="lb-count">
+            <div class="lb-count-inner">
+                <span class="lb-meter"><span class="lb-meter-fill${rankClass}" style="--lb-w: ${pct}%"></span></span>
+                <span class="lb-count-value">${reviews}</span>
+            </div>
+        </td>
+    </tr>`;
+
+    const prs = [...(reviewer.prs || [])].sort((a, b) => (b.engaged_at || '').localeCompare(a.engaged_at || ''));
+    const items = prs.map(renderReviewedPR).join('');
+    const detailRow = `<tr class="lb-detail" id="lb-detail-${index}" hidden>
+        <td class="lb-detail-cell" colspan="3">
+            <table class="lb-pr-table">
+                <thead>
+                    <tr><th>PR</th><th>Repo</th><th>Author</th><th>Reviewed</th></tr>
+                </thead>
+                <tbody>${items}</tbody>
+            </table>
+        </td>
+    </tr>`;
+
+    return mainRow + detailRow;
+}
+
+function renderReviewedPR(pr) {
+    const repo = pr.repo || '';
+    const number = pr.number || 0;
+    const ref = number ? `${repo}#${number}` : repo;
+    const author = pr.author || '';
+    const authorCell = author
+        ? `<a href="https://github.com/${encodeURIComponent(author)}" target="_blank" rel="noopener">${escapeHtml(author)}</a>`
+        : '—';
+    return `<tr>
+        <td class="lb-pr-title"><a href="${escapeHtml(pr.url || '')}" target="_blank" rel="noopener">${escapeHtml(pr.title || ref)}</a></td>
+        <td class="lb-pr-repo">${escapeHtml(repo)}</td>
+        <td class="lb-pr-author">${authorCell}</td>
+        <td class="lb-pr-date">${pr.engaged_at ? escapeHtml(formatDate(pr.engaged_at)) : ''}</td>
+    </tr>`;
+}
+
+function formatDate(iso) {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return '';
+    return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
 }
 
 function formatRelativeTime(date) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,10 +9,20 @@ import (
 )
 
 type Config struct {
-	GitHub  GitHubConfig  `yaml:"github"`
-	Sources SourcesConfig `yaml:"sources"`
-	Authors []string      `yaml:"authors"`
-	UI      UIConfig      `yaml:"-"`
+	GitHub      GitHubConfig      `yaml:"github"`
+	Sources     SourcesConfig     `yaml:"sources"`
+	Authors     []string          `yaml:"authors"`
+	Leaderboard LeaderboardConfig `yaml:"leaderboard"`
+	UI          UIConfig          `yaml:"-"`
+}
+
+// defaultLeaderboardWindowDays is the data horizon used when
+// leaderboard.window_days is omitted. The frontend interval selector can narrow
+// this further, so it is the widest range the leaderboard can show.
+const defaultLeaderboardWindowDays = 90
+
+type LeaderboardConfig struct {
+	WindowDays int `yaml:"window_days"`
 }
 
 type GitHubConfig struct {
@@ -87,6 +97,9 @@ func validate(cfg *Config) (*Config, error) {
 	}
 	if len(cfg.Sources.Orgs) == 0 && len(cfg.Sources.Repos) == 0 {
 		return nil, fmt.Errorf("config: at least one org or repo must be configured")
+	}
+	if cfg.Leaderboard.WindowDays <= 0 {
+		cfg.Leaderboard.WindowDays = defaultLeaderboardWindowDays
 	}
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -54,6 +54,48 @@ authors:
 	}
 }
 
+func TestLoadLeaderboardWindowDefault(t *testing.T) {
+	content := `
+github:
+  app_id: 245286
+  installation_id: 59973090
+sources:
+  orgs:
+    - name: conforma
+`
+	path := writeFile(t, "config.yaml", content)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Leaderboard.WindowDays != defaultLeaderboardWindowDays {
+		t.Errorf("WindowDays = %d, want default %d", cfg.Leaderboard.WindowDays, defaultLeaderboardWindowDays)
+	}
+}
+
+func TestLoadLeaderboardWindowOverride(t *testing.T) {
+	content := `
+github:
+  app_id: 245286
+  installation_id: 59973090
+sources:
+  orgs:
+    - name: conforma
+leaderboard:
+  window_days: 45
+`
+	path := writeFile(t, "config.yaml", content)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Leaderboard.WindowDays != 45 {
+		t.Errorf("WindowDays = %d, want 45", cfg.Leaderboard.WindowDays)
+	}
+}
+
 func TestLoadDir(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/github/leaderboard.go
+++ b/internal/github/leaderboard.go
@@ -1,0 +1,174 @@
+package github
+
+import (
+	"context"
+	"log"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/conforma/review-rot/internal/model"
+	"github.com/shurcooL/githubv4"
+)
+
+// reviewerActivityQuery fetches pull requests ordered by most recently updated,
+// regardless of state, so recent review activity on merged/closed PRs is counted.
+type reviewerActivityQuery struct {
+	Repository struct {
+		PullRequests struct {
+			PageInfo struct {
+				HasNextPage bool
+				EndCursor   githubv4.String
+			}
+			Nodes []reviewerActivityNode
+		} `graphql:"pullRequests(first: 50, orderBy: {field: UPDATED_AT, direction: DESC}, after: $cursor)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+	RateLimit struct {
+		Cost      int
+		Remaining int
+		ResetAt   time.Time
+	}
+}
+
+type reviewerActivityNode struct {
+	Title     string
+	URL       githubv4.URI
+	Number    int
+	UpdatedAt time.Time
+
+	Author struct {
+		Login string
+	} `graphql:"author"`
+
+	Reviews struct {
+		Nodes []struct {
+			Author struct {
+				TypeName string `graphql:"__typename"`
+				Login    string
+			} `graphql:"author"`
+			SubmittedAt time.Time
+		}
+	} `graphql:"reviews(last: 100, states: [APPROVED, CHANGES_REQUESTED, COMMENTED])"`
+
+	Comments struct {
+		Nodes []struct {
+			Author struct {
+				TypeName string `graphql:"__typename"`
+				Login    string
+			} `graphql:"author"`
+			CreatedAt time.Time
+		}
+	} `graphql:"comments(last: 100)"`
+}
+
+// FetchRepoReviewerActivity walks a repo's pull requests from most-recently
+// updated backwards, stopping once it passes the `since` cutoff, and appends
+// each reviewer's per-PR engagement into byReviewer (login -> reviewed PRs).
+func FetchRepoReviewerActivity(ctx context.Context, client *githubv4.Client, repoFullName string, since time.Time, byReviewer map[string][]model.ReviewedPR) error {
+	parts := strings.SplitN(repoFullName, "/", 2)
+	if len(parts) != 2 {
+		log.Printf("Warning: invalid repo name %q, skipping", repoFullName)
+		return nil
+	}
+	owner, name := parts[0], parts[1]
+
+	variables := map[string]interface{}{
+		"owner":  githubv4.String(owner),
+		"name":   githubv4.String(name),
+		"cursor": (*githubv4.String)(nil),
+	}
+
+	for {
+		var query reviewerActivityQuery
+		if err := client.Query(ctx, &query, variables); err != nil {
+			return err
+		}
+
+		reachedCutoff := false
+		for _, node := range query.Repository.PullRequests.Nodes {
+			// Nodes are ordered by UpdatedAt descending; once we pass the
+			// window, every remaining PR is older, so stop paginating.
+			if node.UpdatedAt.Before(since) {
+				reachedCutoff = true
+				break
+			}
+			for login, engagedAt := range extractPRReviewers(node, since) {
+				byReviewer[login] = append(byReviewer[login], model.ReviewedPR{
+					Title:     node.Title,
+					URL:       node.URL.String(),
+					Repo:      repoFullName,
+					Number:    node.Number,
+					Author:    node.Author.Login,
+					EngagedAt: engagedAt.UTC().Format(time.RFC3339),
+				})
+			}
+		}
+
+		if reachedCutoff || !query.Repository.PullRequests.PageInfo.HasNextPage {
+			break
+		}
+		variables["cursor"] = githubv4.NewString(query.Repository.PullRequests.PageInfo.EndCursor)
+	}
+
+	return nil
+}
+
+// extractPRReviewers maps each distinct login that reviewed or commented on the
+// PR within the window to the time of their most recent such activity. It
+// excludes bots and the PR author, mirroring the reviewer-counting rules in
+// extractReviews, with an added per-event window check.
+func extractPRReviewers(node reviewerActivityNode, since time.Time) map[string]time.Time {
+	engaged := make(map[string]time.Time)
+	author := node.Author.Login
+
+	consider := func(login, typeName string, ts time.Time) {
+		if typeName == "Bot" || login == "" || login == author {
+			return
+		}
+		if ts.Before(since) {
+			return
+		}
+		if cur, ok := engaged[login]; !ok || ts.After(cur) {
+			engaged[login] = ts
+		}
+	}
+
+	for _, review := range node.Reviews.Nodes {
+		consider(review.Author.Login, review.Author.TypeName, review.SubmittedAt)
+	}
+	for _, comment := range node.Comments.Nodes {
+		consider(comment.Author.Login, comment.Author.TypeName, comment.CreatedAt)
+	}
+
+	return engaged
+}
+
+// BuildLeaderboard turns aggregated per-reviewer PRs into a sorted leaderboard,
+// ranked by review count descending then login ascending. Each reviewer's PRs
+// are sorted most-recent engagement first.
+func BuildLeaderboard(byReviewer map[string][]model.ReviewedPR, windowDays int, since time.Time) *model.Leaderboard {
+	reviewers := make([]model.ReviewerStat, 0, len(byReviewer))
+	for login, prs := range byReviewer {
+		// EngagedAt is RFC3339 in UTC, so lexical sort equals chronological.
+		sort.Slice(prs, func(i, j int) bool {
+			return prs[i].EngagedAt > prs[j].EngagedAt
+		})
+		reviewers = append(reviewers, model.ReviewerStat{
+			Login:   login,
+			Reviews: len(prs),
+			PRs:     prs,
+		})
+	}
+	sort.Slice(reviewers, func(i, j int) bool {
+		if reviewers[i].Reviews != reviewers[j].Reviews {
+			return reviewers[i].Reviews > reviewers[j].Reviews
+		}
+		return reviewers[i].Login < reviewers[j].Login
+	})
+
+	return &model.Leaderboard{
+		WindowDays: windowDays,
+		Since:      since.UTC().Format(time.RFC3339),
+		Reviewers:  reviewers,
+	}
+}

--- a/internal/github/leaderboard.go
+++ b/internal/github/leaderboard.go
@@ -84,6 +84,10 @@ func FetchRepoReviewerActivity(ctx context.Context, client *githubv4.Client, rep
 			return err
 		}
 
+		log.Printf("  %s: fetched %d PRs (rate limit: %d remaining, resets %s)",
+			repoFullName, len(query.Repository.PullRequests.Nodes),
+			query.RateLimit.Remaining, query.RateLimit.ResetAt.Format(time.RFC3339))
+
 		reachedCutoff := false
 		for _, node := range query.Repository.PullRequests.Nodes {
 			// Nodes are ordered by UpdatedAt descending; once we pass the

--- a/internal/github/leaderboard.go
+++ b/internal/github/leaderboard.go
@@ -122,7 +122,7 @@ func extractPRReviewers(node reviewerActivityNode, since time.Time) map[string]t
 	author := node.Author.Login
 
 	consider := func(login, typeName string, ts time.Time) {
-		if typeName == "Bot" || login == "" || login == author {
+		if isBotLogin(login, typeName) || login == "" || login == author {
 			return
 		}
 		if ts.Before(since) {

--- a/internal/github/leaderboard_test.go
+++ b/internal/github/leaderboard_test.go
@@ -81,8 +81,9 @@ func TestExtractPRReviewersExcludesBotsSelfAndEmpty(t *testing.T) {
 	node.Author.Login = "author"
 	node.Reviews.Nodes = append(node.Reviews.Nodes,
 		makeActivityReview("Bot", "renovate", inWindow),
-		makeActivityReview("User", "author", inWindow), // self-review
-		makeActivityReview("User", "", inWindow),       // ghost/deleted user
+		makeActivityReview("User", "konflux-ci-qe-bot", inWindow), // machine user, bot login suffix
+		makeActivityReview("User", "author", inWindow),            // self-review
+		makeActivityReview("User", "", inWindow),                  // ghost/deleted user
 		makeActivityReview("User", "alice", inWindow),
 	)
 	node.Comments.Nodes = append(node.Comments.Nodes,

--- a/internal/github/leaderboard_test.go
+++ b/internal/github/leaderboard_test.go
@@ -1,0 +1,226 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/conforma/review-rot/internal/model"
+)
+
+func makeActivityReview(authorType, login string, submittedAt time.Time) struct {
+	Author struct {
+		TypeName string `graphql:"__typename"`
+		Login    string
+	} `graphql:"author"`
+	SubmittedAt time.Time
+} {
+	var n struct {
+		Author struct {
+			TypeName string `graphql:"__typename"`
+			Login    string
+		} `graphql:"author"`
+		SubmittedAt time.Time
+	}
+	n.Author.TypeName = authorType
+	n.Author.Login = login
+	n.SubmittedAt = submittedAt
+	return n
+}
+
+func makeActivityComment(authorType, login string, createdAt time.Time) struct {
+	Author struct {
+		TypeName string `graphql:"__typename"`
+		Login    string
+	} `graphql:"author"`
+	CreatedAt time.Time
+} {
+	var n struct {
+		Author struct {
+			TypeName string `graphql:"__typename"`
+			Login    string
+		} `graphql:"author"`
+		CreatedAt time.Time
+	}
+	n.Author.TypeName = authorType
+	n.Author.Login = login
+	n.CreatedAt = createdAt
+	return n
+}
+
+func TestExtractPRReviewersBasic(t *testing.T) {
+	since := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	inWindow := time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+
+	node := reviewerActivityNode{}
+	node.Author.Login = "author"
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeActivityReview("User", "alice", inWindow),
+		makeActivityReview("User", "bob", inWindow),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeActivityComment("User", "charlie", inWindow),
+	)
+
+	got := extractPRReviewers(node, since)
+	want := map[string]bool{"alice": true, "bob": true, "charlie": true}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want keys %v", got, want)
+	}
+	for l := range want {
+		if _, ok := got[l]; !ok {
+			t.Errorf("missing reviewer %q in %v", l, got)
+		}
+	}
+}
+
+func TestExtractPRReviewersExcludesBotsSelfAndEmpty(t *testing.T) {
+	since := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	inWindow := time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+
+	node := reviewerActivityNode{}
+	node.Author.Login = "author"
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeActivityReview("Bot", "renovate", inWindow),
+		makeActivityReview("User", "author", inWindow), // self-review
+		makeActivityReview("User", "", inWindow),       // ghost/deleted user
+		makeActivityReview("User", "alice", inWindow),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeActivityComment("Bot", "codecov", inWindow),
+		makeActivityComment("User", "author", inWindow),
+	)
+
+	got := extractPRReviewers(node, since)
+	if len(got) != 1 {
+		t.Fatalf("got %v, want only alice", got)
+	}
+	if _, ok := got["alice"]; !ok {
+		t.Errorf("got %v, want alice", got)
+	}
+}
+
+func TestExtractPRReviewersWindowFiltering(t *testing.T) {
+	since := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2025, 2, 15, 0, 0, 0, 0, time.UTC)
+	after := time.Date(2025, 3, 10, 0, 0, 0, 0, time.UTC)
+
+	node := reviewerActivityNode{}
+	node.Author.Login = "author"
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeActivityReview("User", "old-reviewer", before), // outside window
+		makeActivityReview("User", "new-reviewer", after),  // inside window
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeActivityComment("User", "old-commenter", before), // outside window
+	)
+
+	got := extractPRReviewers(node, since)
+	if len(got) != 1 {
+		t.Fatalf("got %v, want only new-reviewer", got)
+	}
+	if _, ok := got["new-reviewer"]; !ok {
+		t.Errorf("got %v, want new-reviewer", got)
+	}
+}
+
+func TestExtractPRReviewersUsesLatestEngagement(t *testing.T) {
+	since := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	earlier := time.Date(2025, 3, 5, 0, 0, 0, 0, time.UTC)
+	later := time.Date(2025, 3, 20, 0, 0, 0, 0, time.UTC)
+
+	node := reviewerActivityNode{}
+	node.Author.Login = "author"
+	node.Reviews.Nodes = append(node.Reviews.Nodes,
+		makeActivityReview("User", "alice", earlier),
+	)
+	node.Comments.Nodes = append(node.Comments.Nodes,
+		makeActivityComment("User", "alice", later),
+	)
+
+	got := extractPRReviewers(node, since)
+	if len(got) != 1 {
+		t.Fatalf("got %v, want single alice entry", got)
+	}
+	if !got["alice"].Equal(later) {
+		t.Errorf("alice engagement = %v, want latest %v", got["alice"], later)
+	}
+}
+
+func TestBuildLeaderboardSortsAndTieBreaks(t *testing.T) {
+	since := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	byReviewer := map[string][]model.ReviewedPR{
+		"alice":   prRefs(5),
+		"bob":     prRefs(10),
+		"charlie": prRefs(5),
+		"dave":    prRefs(1),
+	}
+
+	lb := BuildLeaderboard(byReviewer, 30, since)
+
+	if lb.WindowDays != 30 {
+		t.Errorf("WindowDays = %d, want 30", lb.WindowDays)
+	}
+	if lb.Since != "2025-03-01T00:00:00Z" {
+		t.Errorf("Since = %q, want 2025-03-01T00:00:00Z", lb.Since)
+	}
+
+	wantOrder := []string{"bob", "alice", "charlie", "dave"}
+	if len(lb.Reviewers) != len(wantOrder) {
+		t.Fatalf("got %d reviewers, want %d", len(lb.Reviewers), len(wantOrder))
+	}
+	for i, login := range wantOrder {
+		if lb.Reviewers[i].Login != login {
+			t.Errorf("Reviewers[%d].Login = %q, want %q (order: %+v)", i, lb.Reviewers[i].Login, login, lb.Reviewers)
+		}
+	}
+	if lb.Reviewers[0].Reviews != 10 {
+		t.Errorf("top reviewer count = %d, want 10", lb.Reviewers[0].Reviews)
+	}
+	if len(lb.Reviewers[0].PRs) != 10 {
+		t.Errorf("top reviewer PRs = %d, want 10", len(lb.Reviewers[0].PRs))
+	}
+}
+
+func TestBuildLeaderboardSortsPRsByRecency(t *testing.T) {
+	byReviewer := map[string][]model.ReviewedPR{
+		"alice": {
+			{Repo: "o/r", Number: 1, EngagedAt: "2025-03-05T00:00:00Z"},
+			{Repo: "o/r", Number: 2, EngagedAt: "2025-03-20T00:00:00Z"},
+			{Repo: "o/r", Number: 3, EngagedAt: "2025-03-10T00:00:00Z"},
+		},
+	}
+
+	lb := BuildLeaderboard(byReviewer, 30, time.Now())
+	prs := lb.Reviewers[0].PRs
+	wantNumbers := []int{2, 3, 1} // most recent engagement first
+	for i, n := range wantNumbers {
+		if prs[i].Number != n {
+			t.Errorf("PRs[%d].Number = %d, want %d (order: %+v)", i, prs[i].Number, n, prs)
+		}
+	}
+}
+
+func TestBuildLeaderboardEmpty(t *testing.T) {
+	lb := BuildLeaderboard(map[string][]model.ReviewedPR{}, 14, time.Now())
+	if lb == nil {
+		t.Fatal("expected non-nil leaderboard")
+	}
+	if lb.Reviewers == nil {
+		t.Error("expected non-nil (empty) reviewers slice")
+	}
+	if len(lb.Reviewers) != 0 {
+		t.Errorf("expected 0 reviewers, got %d", len(lb.Reviewers))
+	}
+	if lb.WindowDays != 14 {
+		t.Errorf("WindowDays = %d, want 14", lb.WindowDays)
+	}
+}
+
+// prRefs builds n placeholder ReviewedPR entries for count-based assertions.
+func prRefs(n int) []model.ReviewedPR {
+	prs := make([]model.ReviewedPR, n)
+	for i := range prs {
+		prs[i] = model.ReviewedPR{Repo: "o/r", Number: i + 1, EngagedAt: "2025-03-10T00:00:00Z"}
+	}
+	return prs
+}

--- a/internal/github/query.go
+++ b/internal/github/query.go
@@ -178,7 +178,7 @@ func extractReviews(node prNode) model.Reviews {
 	var lastHumanReviewOID string
 	seen := make(map[string]struct{})
 	for _, review := range node.Reviews.Nodes {
-		if review.Author.TypeName == "Bot" {
+		if isBotLogin(review.Author.Login, review.Author.TypeName) {
 			continue
 		}
 		if review.Author.Login == node.Author.Login {
@@ -189,7 +189,7 @@ func extractReviews(node prNode) model.Reviews {
 	}
 	var lastHumanCommentAt time.Time
 	for _, comment := range node.Comments.Nodes {
-		if comment.Author.TypeName == "Bot" {
+		if isBotLogin(comment.Author.Login, comment.Author.TypeName) {
 			continue
 		}
 		if comment.Author.Login == node.Author.Login {
@@ -208,6 +208,17 @@ func extractReviews(node prNode) model.Reviews {
 		r.HasNewCommits = !reviewCoversHead && !commentCoversHead
 	}
 	return r
+}
+
+// isBotLogin reports whether an account belongs to a bot. GitHub App bots carry
+// a "Bot" __typename, but machine users such as konflux-ci-qe-bot authenticate
+// as regular users, so their login is matched by suffix instead.
+func isBotLogin(login, typeName string) bool {
+	if typeName == "Bot" {
+		return true
+	}
+	l := strings.ToLower(login)
+	return strings.HasSuffix(l, "-bot") || strings.HasSuffix(l, "[bot]")
 }
 
 func countUnresolved(node prNode) int {

--- a/internal/github/query_test.go
+++ b/internal/github/query_test.go
@@ -536,3 +536,24 @@ func TestExtractReviewsDeduplicatesByAuthor(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestIsBotLogin(t *testing.T) {
+	cases := []struct {
+		login    string
+		typeName string
+		want     bool
+	}{
+		{"coderabbitai", "Bot", true},       // GitHub App bot
+		{"konflux-ci-qe-bot", "User", true}, // machine user, -bot suffix
+		{"dependabot[bot]", "User", true},   // [bot] suffix without Bot typename
+		{"Konflux-CI-QE-Bot", "User", true}, // suffix match is case-insensitive
+		{"alice", "User", false},            // human
+		{"", "User", false},                 // ghost/deleted user
+		{"robotics-fan", "User", false},     // "bot" mid-word, not a suffix
+	}
+	for _, c := range cases {
+		if got := isBotLogin(c.login, c.typeName); got != c.want {
+			t.Errorf("isBotLogin(%q, %q) = %v, want %v", c.login, c.typeName, got, c.want)
+		}
+	}
+}

--- a/internal/model/pr.go
+++ b/internal/model/pr.go
@@ -6,6 +6,34 @@ type Output struct {
 	GeneratedAt  time.Time     `json:"generated_at"`
 	UISettings   *UISettings   `json:"ui_settings,omitempty"`
 	PullRequests []PullRequest `json:"pull_requests"`
+	Leaderboard  *Leaderboard  `json:"leaderboard,omitempty"`
+}
+
+// Leaderboard ranks reviewers by how many pull requests they reviewed or
+// commented on within a recent time window across the monitored repos.
+// WindowDays is the data horizon: the frontend can narrow it further with a
+// client-side interval selector using each PR's EngagedAt timestamp.
+type Leaderboard struct {
+	WindowDays int            `json:"window_days"`
+	Since      string         `json:"since"`
+	Reviewers  []ReviewerStat `json:"reviewers"`
+}
+
+type ReviewerStat struct {
+	Login   string       `json:"login"`
+	Reviews int          `json:"reviews"`
+	PRs     []ReviewedPR `json:"prs"`
+}
+
+// ReviewedPR is a pull request a reviewer engaged with, plus the time of their
+// most recent review or comment on it (used for client-side interval filtering).
+type ReviewedPR struct {
+	Title     string `json:"title"`
+	URL       string `json:"url"`
+	Repo      string `json:"repo"`
+	Number    int    `json:"number"`
+	Author    string `json:"author"`
+	EngagedAt string `json:"engaged_at"`
 }
 
 type UISettings struct {


### PR DESCRIPTION
Adds a Leaderboard tab that ranks people by the number of distinct PRs they reviewed or commented on across the monitored repos. Activity on PRs of any state counts (open, merged, closed); bots and self-reviews are excluded, matching the reviewer count already shown on the PR list.

## Backend
- Walks each repo's PRs newest-first and stops once it passes the window cutoff.
- Emits per-reviewer PR lists carrying each PR's author and engagement timestamp.
- `leaderboard.window_days` (default 90) is a data horizon: the widest range aggregated. The frontend narrows it client-side, so raising it doesn't force a rebuild.

## Frontend
- Separate tab with an interval slider (0 to the horizon, plus preset shortcuts) that re-counts and re-ranks per window.
- Each row is an accordion that opens a table of the PRs behind the count (PR, repo, author, review date), sorted most recent first.
- Count bars grow on render, flat Material style, with podium colors for the top three.
- View, interval, and active tab persist in the URL.

## Testing
- Go tests added for the config window and leaderboard aggregation; `go build`, `go vet`, `go test ./...` all pass.
- Frontend behavior verified against the rendered DOM: tab switching, accordion expand/collapse, slider re-ranking across windows, and URL deep links.

Config: `config/sources.yaml` sets `leaderboard.window_days: 90`.

Ref: https://redhat.atlassian.net/browse/EC-2107
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
