### PR TITLE
Restrict reviewer leaderboard to configured team members

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,13 @@ secret, passed as the `GITHUB_PRIVATE_KEY` environment variable.
 - Bot detection: PRs from authors in the `bots` list are flagged as automated
 - Frontend uses vanilla JS with no dependencies or build step
 - Reviewer leaderboard aggregates review/comment activity across PRs of any
-  state within a configurable data horizon; the backend emits each reviewer's
-  PR list with per-PR author and engagement timestamp. The frontend shows it in
-  a separate tab with a client-side interval slider (0..horizon, narrows and
-  re-ranks) and per-row accordions that open a table (PR/repo/author/reviewed
-  date) of the PRs behind each count
+  state within a configurable data horizon, restricted to the team members in
+  `authors` (or every reviewer, if `authors` is empty); the backend emits each
+  reviewer's PR list with per-PR author and
+  engagement timestamp. The frontend shows it in a separate tab with a
+  client-side interval slider (1..horizon, narrows and re-ranks) and per-row
+  accordions that open a table (PR/repo/author/reviewed date) of the PRs behind
+  each count
 - Data refreshed every 30 minutes on weekdays via GitHub Actions cron
 - Dashboard appearance (title, logo, colors) is configured via `config/ui.yaml`
   and injected into `data.json` as `ui_settings`; the frontend applies them at

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ The `config/` directory contains two files:
   default 90). See the comments in that file for details.
 - **`ui.yaml`** — Dashboard appearance: title, logo, and accent colors.
 
-The **Leaderboard** tab ranks people by the number of distinct PRs they reviewed
-or commented on across the monitored repos. It counts activity on PRs of any
-state (open, merged, or closed) and excludes bots and self-reviews, matching the
-reviewer count shown on the PR list.
+The **Leaderboard** tab ranks the team members listed under `authors` by the
+number of distinct PRs they reviewed or commented on across the monitored repos.
+It counts activity on PRs of any state (open, merged, or closed) and excludes
+bots and self-reviews. If `authors` is empty, every reviewer is ranked.
 
 `leaderboard.window_days` is the data horizon — the widest range the backend
-aggregates. The tab has an interval slider (0 to the horizon, with preset
+aggregates. The tab has an interval slider (1 to the horizon, with preset
 shortcuts like 7d / 30d / 90d) that narrows the window client-side, re-counting
 and re-ranking without a rebuild. Each row is an accordion: clicking it opens a
 table of the PRs behind that person's count — PR title, repo, author, and review

--- a/cmd/review-rot/main.go
+++ b/cmd/review-rot/main.go
@@ -69,7 +69,7 @@ func main() {
 			continue
 		}
 	}
-	leaderboard := gh.BuildLeaderboard(reviewsByPerson, cfg.Leaderboard.WindowDays, since)
+	leaderboard := gh.BuildLeaderboard(reviewsByPerson, cfg.Leaderboard.WindowDays, since, cfg.Authors)
 	log.Printf("Leaderboard: %d reviewers over the last %d days", len(leaderboard.Reviewers), cfg.Leaderboard.WindowDays)
 
 	output := model.Output{

--- a/internal/github/leaderboard.go
+++ b/internal/github/leaderboard.go
@@ -150,9 +150,20 @@ func extractPRReviewers(node reviewerActivityNode, since time.Time) map[string]t
 // BuildLeaderboard turns aggregated per-reviewer PRs into a sorted leaderboard,
 // ranked by review count descending then login ascending. Each reviewer's PRs
 // are sorted most-recent engagement first.
-func BuildLeaderboard(byReviewer map[string][]model.ReviewedPR, windowDays int, since time.Time) *model.Leaderboard {
+//
+// teamAuthors restricts the board to the configured team members, matching by
+// login case-insensitively like FilterPRs. An empty list keeps every reviewer.
+func BuildLeaderboard(byReviewer map[string][]model.ReviewedPR, windowDays int, since time.Time, teamAuthors []string) *model.Leaderboard {
+	allowed := make(map[string]bool, len(teamAuthors))
+	for _, a := range teamAuthors {
+		allowed[strings.ToLower(a)] = true
+	}
+
 	reviewers := make([]model.ReviewerStat, 0, len(byReviewer))
 	for login, prs := range byReviewer {
+		if len(allowed) > 0 && !allowed[strings.ToLower(login)] {
+			continue
+		}
 		// EngagedAt is RFC3339 in UTC, so lexical sort equals chronological.
 		sort.Slice(prs, func(i, j int) bool {
 			return prs[i].EngagedAt > prs[j].EngagedAt

--- a/internal/github/leaderboard_test.go
+++ b/internal/github/leaderboard_test.go
@@ -156,7 +156,7 @@ func TestBuildLeaderboardSortsAndTieBreaks(t *testing.T) {
 		"dave":    prRefs(1),
 	}
 
-	lb := BuildLeaderboard(byReviewer, 30, since)
+	lb := BuildLeaderboard(byReviewer, 30, since, nil)
 
 	if lb.WindowDays != 30 {
 		t.Errorf("WindowDays = %d, want 30", lb.WindowDays)
@@ -191,7 +191,7 @@ func TestBuildLeaderboardSortsPRsByRecency(t *testing.T) {
 		},
 	}
 
-	lb := BuildLeaderboard(byReviewer, 30, time.Now())
+	lb := BuildLeaderboard(byReviewer, 30, time.Now(), nil)
 	prs := lb.Reviewers[0].PRs
 	wantNumbers := []int{2, 3, 1} // most recent engagement first
 	for i, n := range wantNumbers {
@@ -202,7 +202,7 @@ func TestBuildLeaderboardSortsPRsByRecency(t *testing.T) {
 }
 
 func TestBuildLeaderboardEmpty(t *testing.T) {
-	lb := BuildLeaderboard(map[string][]model.ReviewedPR{}, 14, time.Now())
+	lb := BuildLeaderboard(map[string][]model.ReviewedPR{}, 14, time.Now(), nil)
 	if lb == nil {
 		t.Fatal("expected non-nil leaderboard")
 	}
@@ -214,6 +214,32 @@ func TestBuildLeaderboardEmpty(t *testing.T) {
 	}
 	if lb.WindowDays != 14 {
 		t.Errorf("WindowDays = %d, want 14", lb.WindowDays)
+	}
+}
+
+func TestBuildLeaderboardFiltersToTeam(t *testing.T) {
+	since := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	byReviewer := map[string][]model.ReviewedPR{
+		"alice":     prRefs(3),
+		"outsider":  prRefs(5),
+		"BohdanMar": prRefs(2),
+	}
+
+	// Allowlist uses different casing to confirm the match is case-insensitive.
+	lb := BuildLeaderboard(byReviewer, 30, since, []string{"Alice", "bohdanmar"})
+
+	if len(lb.Reviewers) != 2 {
+		t.Fatalf("got %d reviewers, want 2 (team only): %+v", len(lb.Reviewers), lb.Reviewers)
+	}
+	seen := map[string]bool{}
+	for _, r := range lb.Reviewers {
+		seen[r.Login] = true
+	}
+	if !seen["alice"] || !seen["BohdanMar"] {
+		t.Errorf("expected alice and BohdanMar, got %+v", lb.Reviewers)
+	}
+	if seen["outsider"] {
+		t.Errorf("outsider should be excluded, got %+v", lb.Reviewers)
 	}
 }
 


### PR DESCRIPTION
The reviewer leaderboard ranked every account that reviewed or commented on a monitored PR. On the published board that meant dozens of outside contributors showed up alongside the team.

Filter reviewers against the `authors` list in `sources.yaml`, matching login case-insensitively the way `FilterPRs` already does. An empty list keeps every reviewer, so nothing changes for setups without a configured team.

- `BuildLeaderboard` takes a `teamAuthors` argument and skips logins outside it
- `main.go` passes `cfg.Authors`
- Added `TestBuildLeaderboardFiltersToTeam`; README and AGENTS.md updated for the new scope

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
